### PR TITLE
Add `CINEMA4D_ADAPTOR_CINEMA4D_EXE` env var

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,5 +67,5 @@ Example linux env below:
 
 ```
 export DEADLINE_CLOUD_PYTHONPATH="/tmp/lib/python3.11/site-packages"
-export DEADLINE_CINEMA4D_EXE="/opt/maxon/cinema4dr2024.200/bin/c4d"
+export CINEMA4D_ADAPTOR_CINEMA4D_EXE="/opt/maxon/cinema4dr2024.200/bin/c4d"
 ```

--- a/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
+++ b/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py
@@ -271,7 +271,9 @@ class Cinema4DAdaptor(Adaptor[AdaptorConfiguration]):
         # XXX: on linux we need to run the c4d env setup script first, this env
         # var allows us to use a wrapper around Commandline. Ideally a conda env
         # does this for us.
-        c4d_exe_env = os.getenv("DEADLINE_CINEMA4D_EXE", "")
+        # On Linux this should be a path similar to this: /opt/maxon/cinema4dr2024.200/bin/c4d
+        # On Windows it should be a path similar to this: "C:\Program Files\Maxon Cinema 4D R26\Commandline.exe"
+        c4d_exe_env = os.getenv("CINEMA4D_ADAPTOR_CINEMA4D_EXE", "")
         if not c4d_exe_env:
             c4d_exe = "Commandline"
         else:


### PR DESCRIPTION
This should be a path to "Commandline.exe" for Windows and "c4d" for Linux.

Example paths are:
"C:\Program Files\Maxon Cinema 4D R26\Commandline.exe" "/opt/maxon/cinema4dr2024.200/bin/c4d"

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*