### PR TITLE
Change ambiguous DEADLINE_CLOUD_PYTHONPATH env var

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,7 @@ hatch run all:test
 
 ## Get started
 
-Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
+Cinema4D does not support PYTHONPATH. We set CINEMA4D_DEADLINE_CLOUD_PYTHONPATH which the
 submitter uses to set sys.path explictly and load deadline modules.
 
 - install deadline-cloud with pyside
@@ -46,7 +46,7 @@ submitter uses to set sys.path explictly and load deadline modules.
 
 ```
 # deadline-cloud lib with pyside
-export DEADLINE_CLOUD_PYTHONPATH="/path/to/deadline-cloud/site-packages"
+export CINEMA4D_DEADLINE_CLOUD_PYTHONPATH="/path/to/deadline-cloud/site-packages"
 # configure cinema4d to find extension entry point
 export g_additionalModulePath="/path/to/deadline-cloud-for-cinema4d/deadline_cloud_extension"
 ```
@@ -56,7 +56,7 @@ export g_additionalModulePath="/path/to/deadline-cloud-for-cinema4d/deadline_clo
 
 ## Worker environment
 
-Cinema4D does not support PYTHONPATH. We set DEADLINE_CLOUD_PYTHONPATH which the
+Cinema4D does not support PYTHONPATH. We set CINEMA4D_DEADLINE_CLOUD_PYTHONPATH which the
 adaptor uses to set sys.path explictly and load deadline modules.
 
 Linux also requires the setup_c4d_env sourced first, we can override the exe
@@ -66,6 +66,6 @@ client.
 Example linux env below:
 
 ```
-export DEADLINE_CLOUD_PYTHONPATH="/tmp/lib/python3.11/site-packages"
+export CINEMA4D_DEADLINE_CLOUD_PYTHONPATH="/tmp/lib/python3.11/site-packages"
 export CINEMA4D_ADAPTOR_CINEMA4D_EXE="/opt/maxon/cinema4dr2024.200/bin/c4d"
 ```

--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -5,7 +5,7 @@ root = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(root, 'modules'))
 
 if 'cinema4d_submitter' not in sys.modules.keys():
-    python_path = os.getenv('DEADLINE_CLOUD_PYTHONPATH')
+    python_path = os.getenv('CINEMA4D_DEADLINE_CLOUD_PYTHONPATH')
     python_paths = python_path.split(os.pathsep)
     for n in python_paths:
         if n not in sys.path:

--- a/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
+++ b/src/deadline/cinema4d_adaptor/Cinema4DClient/plugin/DeadlineCloudClient.pyp
@@ -12,7 +12,7 @@ for n in sys.path:
 
 # cinema4d doesn't use PYTHONPATH so explicitly load modules
 if 'openjd' not in sys.modules.keys():
-    python_path = os.getenv('DEADLINE_CLOUD_PYTHONPATH')
+    python_path = os.getenv('CINEMA4D_DEADLINE_CLOUD_PYTHONPATH')
     python_paths = python_path.split(os.pathsep)
     for p in python_paths:
         if sys.platform == 'win32':


### PR DESCRIPTION
It is now `CINEMA4D_DEADLINE_CLOUD_PYTHONPATH` as it only applies to C4D

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*