### PR TITLE
Forcefully add the dll path for C4D python

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,38 +1,17 @@
 name: "Release: Publish"
 run-name: "Release: ${{ github.event.head_commit.message }}"
 
-on:
-  push:
-    branches:
-      - mainline
-    paths:
-      - CHANGELOG.md
 
-concurrency:
-  group: release
+on:
+  release:
+    types: [published]
 
 jobs:
-  Publish:
-    name: Publish Release
-    permissions:
-      id-token: write
-      contents: write
-    uses: aws-deadline/.github/.github/workflows/reusable_publish.yml@mainline
-    secrets: inherit
-  # PyPI does not support reusable workflows yet
-  # # See https://github.com/pypi/warehouse/issues/11096
-  PublishToPyPI:
-    needs: Publish
+  PublishTo:
     runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: release
-          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -40,8 +19,21 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade hatch
-      - name: Build
-        run: hatch -v build
-      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Export Built Files
+        id: export-files
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          hatch -v build
+          echo "whl-path=${GITHUB_WORKSPACE}/dist/deadline_cloud_for_cinema_4d-${GITHUB_REF##*/}-py3-none-any.whl" >> ${GITHUB_OUTPUT}
+          echo "tgz-path=${GITHUB_WORKSPACE}/dist/deadline_cloud_for_cinema_4d-${GITHUB_REF##*/}.tar.gz" >> ${GITHUB_OUTPUT}
+          echo "plugin-path=${GITHUB_WORKSPACE}/deadline_cloud_extension/DeadlineCloud.pyp" >> ${GITHUB_OUTPUT}
+      - name: Upload Release Asset
+        id: upload-release-asset-windows
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{steps.export-files.outputs.whl-path}}
+            ${{steps.export-files.outputs.tgz-path}}
+            ${{steps.export-files.outputs.plugin-path}}
+

--- a/deadline_cloud_extension/DeadlineCloud.pyp
+++ b/deadline_cloud_extension/DeadlineCloud.pyp
@@ -1,5 +1,28 @@
+import functools
+import glob
 import os
 import sys
+
+
+def glob_add_path(base, pattern):
+    matches = list(glob.iglob(os.path.join(base, pattern)))
+    if matches:
+        return os.path.join(base, matches[0])
+    return base
+
+if "win" in sys.platform:
+    paths = [
+        "resource",
+        "modules",
+        "python",
+        "libs",
+        "*win64*",
+        "dlls"
+    ]
+    dll_path = functools.reduce(glob_add_path, paths, os.path.dirname(sys.executable))
+    # Required due to a longstanding bug in C4D to not include the python dll library path required by many compiled libs
+    #   Read more here: https://github.com/danbradham/wheels/issues/4#issuecomment-1772721170
+    os.add_dll_directory(dll_path)
 
 root = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(root, 'modules'))


### PR DESCRIPTION
This allows third party compiled PyPi module (such as PySide6) to correctly locate the python.dll

See here for more information: https://github.com/danbradham/wheels/issues/4#issuecomment-1772721170

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*